### PR TITLE
The `usefulAnnotations` appears to be deprecated and replaced by `allAnnotationsAreUseful`

### DIFF
--- a/MyOnlineStore/ruleset.xml
+++ b/MyOnlineStore/ruleset.xml
@@ -112,53 +112,7 @@
     <rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration">
         <properties>
             <property name="enableEachParameterAndReturnInspection" value="true"/>
-            <property name="usefulAnnotations" type="array">
-                <element value="@after"/>
-                <element value="@afterClass"/>
-                <element value="@AfterMethods"/>
-                <element value="@Attribute"/>
-                <element value="@Attributes"/>
-                <element value="@before"/>
-                <element value="@beforeClass"/>
-                <element value="@BeforeMethods"/>
-                <element value="@codeCoverageIgnore"/>
-                <element value="@covers"/>
-                <element value="@coversDefaultClass"/>
-                <element value="@coversNothing"/>
-                <element value="@dataProvider"/>
-                <element value="@depends"/>
-                <element value="@deprecated"/>
-                <element value="@doesNotPerformAssertions"/>
-                <element value="@Enum"/>
-                <element value="@expectedDeprecation"/>
-                <element value="@expectedException"/>
-                <element value="@expectedExceptionCode"/>
-                <element value="@expectedExceptionMessage"/>
-                <element value="@expectedExceptionMessageRegExp"/>
-                <element value="@group"/>
-                <element value="@Groups"/>
-                <element value="@IgnoreAnnotation"/>
-                <element value="@internal"/>
-                <element value="@Iterations"/>
-                <element value="@link"/>
-                <element value="@Method"/>
-                <element value="@ODM\"/>
-                <element value="@ORM\"/>
-                <element value="@ParamConverter"/>
-                <element value="@Route"/>
-                <element value="@requires"/>
-                <element value="@Required"/>
-                <element value="@Revs"/>
-                <element value="@runInSeparateProcess"/>
-                <element value="@runTestsInSeparateProcesses"/>
-                <element value="@see"/>
-                <element value="@Target"/>
-                <element value="@Template"/>
-                <element value="@test"/>
-                <element value="@throws"/>
-                <element value="@todo"/>
-                <element value="@uses"/>
-            </property>
+            <property name="allAnnotationsAreUseful" value="true"/>
         </properties>
     </rule>
     <!-- Require using Throwable instead of Exception -->


### PR DESCRIPTION
To prevent false positives with doctrine/symfony/etc annotations, enable
`allAnnotationsAreUseful`.

(See https://github.com/slevomat/coding-standard/releases/tag/4.6.0)