### PR TITLE
Require single-line property docblocks

### DIFF
--- a/MyOnlineStore/ruleset.xml
+++ b/MyOnlineStore/ruleset.xml
@@ -265,6 +265,8 @@
     <rule ref="SlevomatCodingStandard.ControlStructures.DisallowContinueWithoutIntegerOperandInSwitch"/>
     <!-- Reports functions that should not be invoked with argument unpacking -->
     <rule ref="SlevomatCodingStandard.PHP.OptimizedFunctionsWithoutUnpacking"/>
+    <!-- Require single line property docblocks -->
+    <rule ref="SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment"/>
 
     <!-- Forbid spaces around square brackets -->
     <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>

--- a/README.md
+++ b/README.md
@@ -10,11 +10,25 @@ composer require myonlinestore/coding-standard
 Add the ruleset to your `phpcs.xml.dist` file:
 ```xml
 <?xml version="1.0"?>
-<ruleset
-        name="MyOnlineStore"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd"
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd"
 >
+    <arg name="basepath" value="."/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+    <arg value="sp"/>
+
+    <file>src</file>
+    <file>tests</file>
+
     <rule ref="vendor/myonlinestore/coding-standard/MyOnlineStore/ruleset.xml"/>
 </ruleset>
+```
+
+
+## Monolith Excludes
+```xml
+<exclude name="SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment"/>
 ```


### PR DESCRIPTION
Only available for the 7.2 branch.
Should be excluded in the monolith as documented in the readme.