### PR TITLE
Allow unused parameters sometimes required by an interface

### DIFF
--- a/MyOnlineStore/ruleset.xml
+++ b/MyOnlineStore/ruleset.xml
@@ -127,8 +127,6 @@
     </rule>
     <!-- Forbid weak comparisons -->
     <rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators"/>
-    <!-- Forbid dead code -->
-    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements"/>
     <!-- Forbid unused use statements -->
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
         <properties>
@@ -247,7 +245,6 @@
         </properties>
     </rule>
     <rule ref="SlevomatCodingStandard.Variables.UselessVariable"/>
-    <rule ref="SlevomatCodingStandard.Functions.UnusedParameter"/>
     <rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure"/>
     <!-- Useless code -->
     <rule ref="SlevomatCodingStandard.Namespaces.UselessAlias"/>


### PR DESCRIPTION
Sometimes certain parameters are unused but required when implementing an interface. CS should not fail in these cases. Similar, unused class properties might occur for instance in a doctrine entity.

This PR removes the requirement that the above is not allowed.