### PR TITLE
Upgrade to allow PHP 8

### DIFF
--- a/MyOnlineStore/ruleset.xml
+++ b/MyOnlineStore/ruleset.xml
@@ -100,10 +100,4 @@
             <property name="spacesCountBeforeColon" value="0"/>
         </properties>
     </rule>
-
-    <rule ref="Squiz.Strings.ConcatenationSpacing">
-        <properties>
-            <property name="spacing" value="0"/>
-        </properties>
-    </rule>
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -5,18 +5,15 @@
     "homepage": "https://github.com/MyOnlineStore/coding-standard",
     "license": "MIT",
     "require": {
-        "php": "^7.2",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
-        "doctrine/coding-standard": "^7.0",
+        "php": "^7.2 || ^8.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+        "doctrine/coding-standard": "^8.1",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master"
     },
     "config": {
-        "sort-packages": true,
-        "platform": {
-            "php": "7.2.24"
-        }
+        "sort-packages": true
     }
 }


### PR DESCRIPTION
Allow the package to be used with PHP 8.
Upgrades Doctrine Coding-Standard from `7.x` to `8.x`, which includes [PSR-12](https://www.php-fig.org/psr/psr-12/).

Notable breaking changes (from PSR-12):
- Spaces are now required before and after `.` operator.
- Multi-line if-statements must start on a new line, eg:
```php
if ($foo->isBar() &&
    $bar->isFoo()
) {}

// Becomes

if (
    $foo->isBar() &&
    $bar->isFoo()
) {}
```

Changes in effect: https://github.com/MyOnlineStore/configuration/pull/209

Must be released as new major.