### PR TITLE
feat: Partial PHP 8.1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,14 +5,18 @@
     "homepage": "https://github.com/MyOnlineStore/coding-standard",
     "license": "MIT",
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-        "doctrine/coding-standard": "^9.0"
+        "doctrine/coding-standard": "^9.0",
+        "squizlabs/php_codesniffer": "dev-master"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }


### PR DESCRIPTION
Use `squizlabs/php_codesniffer:dev-master`, that has partial support for PHP 8.1.