### PR TITLE
chore: Upgrade to Doctrine Coding Standard 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,9 @@
     "homepage": "https://github.com/MyOnlineStore/coding-standard",
     "license": "MIT",
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-        "doctrine/coding-standard": "^9.0",
-        "squizlabs/php_codesniffer": "dev-master"
+        "doctrine/coding-standard": "10.0.x-dev"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest"


### PR DESCRIPTION
Adds PHP 8.1 compatibility. To be able to install, add `"doctrine/coding-standard": "10.0.x-dev"` to your require-dev as well.


Major changes:
- Multi-line function calls must have a trailing comma, similar to multi-line arrays.
- Short nullable types are no longer allowed: https://github.com/doctrine/orm/pull/9886#discussion_r919031700