### PR TITLE
chore(ruleset): Remove Yoda-comparison requirement.

### DIFF
--- a/MyOnlineStore/ruleset.xml
+++ b/MyOnlineStore/ruleset.xml
@@ -65,8 +65,6 @@
         </properties>
     </rule>
 
-    <rule ref="SlevomatCodingStandard.ControlStructures.RequireYodaComparison"/>
-
     <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalConstants"/>
 
     <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions"/>


### PR DESCRIPTION
## 🌟 Summary.
This pull request disables the requirement of Yoda-style comparisons.

Yoda-style comparisons will not be disallowed, so it is up to the author's preference which style they apply.

## 📝 Changelog.
- Removed `SlevomatCodingStandard.ControlStructures.RequireYodaComparison` rule.